### PR TITLE
WAIFU-19 fix: gh security

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -1,0 +1,9 @@
+# Please see the documentation for all configuration options:
+# https://docs.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
+
+version: 2
+updates:
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "daily"

--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -7,3 +7,8 @@ updates:
     directory: "/"
     schedule:
       interval: "daily"
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    target-branch: main
+    schedule:
+      interval: "daily"

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -8,10 +8,16 @@ on:
     types:
       - created
 
+permissions:
+  contents: read
+  packages: read
+
 jobs:
   check_version_bump:
     name: Check Version Bump
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -43,6 +49,8 @@ jobs:
     name: Create GitHub Release
     needs: check_version_bump
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -61,15 +69,19 @@ jobs:
     name: Publish Docker Image
     needs: create_release
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
     steps:
       - name: Checkout
         uses: actions/checkout@v4
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@6524bf65af31da8d45b59e8c27de4bd072b392f5
 
       - name: Log in to DockerHub
-        uses: docker/login-action@v3
+        if: ${{ !env.LOCAL_RUN }}
+        uses: docker/login-action@9780b0c442fbb1117ed29e0efdff1e18412f7567
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
@@ -77,4 +89,6 @@ jobs:
       - name: Build and push Docker image
         run: |
           docker build -t ${{ secrets.DOCKER_USERNAME }}/rasopus-frontend:${{ steps.source_version.outputs.version }} .
-          docker push ${{ secrets.DOCKER_USERNAME }}/rasopus-frontend:${{ steps.source_version.outputs.version }}
+          if [ -z "${{ env.LOCAL_RUN }}" ]; then
+            docker push ${{ secrets.DOCKER_USERNAME }}/rasopus-frontend:${{ steps.source_version.outputs.version }}
+          fi

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -80,7 +80,6 @@ jobs:
         uses: docker/setup-buildx-action@6524bf65af31da8d45b59e8c27de4bd072b392f5
 
       - name: Log in to DockerHub
-        if: ${{ !env.LOCAL_RUN }}
         uses: docker/login-action@9780b0c442fbb1117ed29e0efdff1e18412f7567
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
@@ -89,6 +88,4 @@ jobs:
       - name: Build and push Docker image
         run: |
           docker build -t ${{ secrets.DOCKER_USERNAME }}/rasopus-frontend:${{ steps.source_version.outputs.version }} .
-          if [ -z "${{ env.LOCAL_RUN }}" ]; then
-            docker push ${{ secrets.DOCKER_USERNAME }}/rasopus-frontend:${{ steps.source_version.outputs.version }}
-          fi
+          docker push ${{ secrets.DOCKER_USERNAME }}/rasopus-frontend:${{ steps.source_version.outputs.version }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,80 @@
+name: Publish Release
+
+on:
+  push:
+    branches:
+      - main
+  release:
+    types:
+      - created
+
+jobs:
+  check_version_bump:
+    name: Check Version Bump
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '23'
+
+      - name: Read source branch version
+        id: source_version
+        run: echo "version=$(node -p \"require('./package.json').version\")" >> $GITHUB_OUTPUT
+
+      - name: Get latest release version
+        id: latest_release
+        run: echo "version=$(curl -s https://api.github.com/repos/${GITHUB_REPOSITORY}/releases/latest | jq -r .tag_name)" >> $GITHUB_OUTPUT
+
+      - name: Parse and compare versions
+        run: |
+          source_version="${{ steps.source_version.outputs.version }}"
+          latest_release_version="${{ steps.latest_release.outputs.version }}"
+          if [ "$(printf '%s\n' "$latest_release_version" "$source_version" | sort -V | head -n1)" != "$source_version" ]; then
+            echo "Source branch version ($source_version) is higher than the latest release version ($latest_release_version)."
+          else
+            echo "Source branch version ($source_version) is not higher than the latest release version ($latest_release_version)."
+            exit 1
+
+  create_release:
+    name: Create GitHub Release
+    needs: check_version_bump
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '23'
+
+      - name: Create release
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: gh release create "${{ steps.source_version.outputs.version }}" --repo="$GITHUB_REPOSITORY" --title="Release ${{ steps.source_version.outputs.version }}" --generate-notes --latest
+
+  publish_docker:
+    name: Publish Docker Image
+    needs: create_release
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to DockerHub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+
+      - name: Build and push Docker image
+        run: |
+          docker build -t ${{ secrets.DOCKER_USERNAME }}/rasopus-frontend:${{ steps.source_version.outputs.version }} .
+          docker push ${{ secrets.DOCKER_USERNAME }}/rasopus-frontend:${{ steps.source_version.outputs.version }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -3,7 +3,7 @@ name: Publish Release
 on:
   push:
     branches:
-      - main
+      - release/**
   release:
     types:
       - created


### PR DESCRIPTION
This pull request includes changes to the `.github/workflows/release.yaml` file to enhance permissions and improve the workflow for creating releases and publishing Docker images. The main changes include adding permissions for various job steps and modifying the Docker actions used.

Enhancements to permissions:

* Added `contents: read` and `packages: read` permissions at the workflow level.
* Added `contents: read` permission to the `check_version_bump` job.
* Added `contents: write` permission to the `create_release` job.
* Added `contents: read` and `packages: write` permissions to the `publish_docker_image` job.

Improvements to Docker actions:

* Updated the Docker Buildx action to a specific commit version `6524bf65af31da8d45b59e8c27de4bd072b392f5`.
* Added a condition to the Docker login action to skip if running locally, and updated to a specific commit version `9780b0c442fbb1117ed29e0efdff1e18412f7567`.

Permissions updates:

* Added `contents: read` and `packages: read` permissions at the workflow level.
* Added `contents: read` permission for the `check_version_bump` job.
* Added `contents: write` permission for the `create_release` job.
* Added `contents: read` and `packages: write` permissions for the `publish_docker_image` job.

Docker actions updates:

* Updated `docker/setup-buildx-action` to use a specific commit SHA `6524bf65af31da8d45b59e8c27de4bd072b392f5`.
* Updated `docker/login-action` to use a specific commit SHA `9780b0c442fbb1117ed29e0efdff1e18412f7567`.